### PR TITLE
lib: stop using named variadic macro args to be less GCC-extension dependent

### DIFF
--- a/usdt.h
+++ b/usdt.h
@@ -97,8 +97,8 @@
  * record their locations in CPU registers or in memory for tracing tooling to
  * be able to access them, if necessary.
  */
-#define USDT(group, name, args...)						\
-	__usdt_probe(group, name, __usdt_sema_none, 0, ##args)
+#define USDT(group, name, ...)							\
+	__usdt_probe(group, name, __usdt_sema_none, 0, ##__VA_ARGS__)
 
 /*
  * Trigger USDT with `group`:`name` identifier and pass through `args` as its
@@ -139,10 +139,10 @@
  * called out here. (Static libraries become a part of final executable, once
  * linked by linker, so the above considerations don't apply to them.)
  */
-#define USDT_WITH_SEMA(group, name, args...)					\
+#define USDT_WITH_SEMA(group, name, ...)					\
 	__usdt_probe(group, name,						\
 		     __usdt_sema_implicit, __usdt_sema_name(group, name),	\
-		     ##args)
+		     ##__VA_ARGS__)
 
 struct usdt_sema { volatile unsigned short active; };
 
@@ -265,8 +265,8 @@ struct usdt_sema { volatile unsigned short active; };
  * Semaphore is defined with the help of USDT_DEFINE_SEMA() macro and can be
  * checked whether active with USDT_SEMA_IS_ACTIVE().
  */
-#define USDT_WITH_EXPLICIT_SEMA(sema, group, name, args...)			\
-	__usdt_probe(group, name, __usdt_sema_explicit, USDT_SEMA(sema), ##args)
+#define USDT_WITH_EXPLICIT_SEMA(sema, group, name, ...)				\
+	__usdt_probe(group, name, __usdt_sema_explicit, USDT_SEMA(sema), ##__VA_ARGS__)
 
 /*
  * Adjustable implementation aspects
@@ -353,7 +353,7 @@ struct usdt_sema { volatile unsigned short active; };
 	__asm__ __volatile__ ("" :: "m" (sema));
 
 /* main USDT definition (nop and .note.stapsdt metadata) */
-#define __usdt_probe(group, name, sema_def, sema, args...) do {					\
+#define __usdt_probe(group, name, sema_def, sema, ...) do {					\
 	sema_def(sema)										\
 	__asm__ __volatile__ (									\
 	__usdt_asm1(990:	USDT_NOP)							\
@@ -367,7 +367,7 @@ struct usdt_sema { volatile unsigned short active; };
 	__usdt_asm1(		__usdt_asm_addr sema)						\
 	__usdt_asm_strz(group)									\
 	__usdt_asm_strz(name)									\
-	__usdt_asm_args(args)									\
+	__usdt_asm_args(__VA_ARGS__)								\
 	__usdt_asm1(		.ascii "\0")							\
 	__usdt_asm1(994:	.balign 4)							\
 	__usdt_asm1(		.popsection)							\
@@ -380,7 +380,7 @@ struct usdt_sema { volatile unsigned short active; };
 	__usdt_asm2(		.size _.stapsdt.base, 1)					\
 	__usdt_asm1(		.popsection)							\
 	__usdt_asm1(.endif)									\
-	:: __usdt_asm_ops(args)									\
+	:: __usdt_asm_ops(__VA_ARGS__)								\
 	);											\
 } while (0)
 


### PR DESCRIPTION
args... usage is unnecessary (even if a bit nicer than __VA_ARGS__), but some more pedantic setups will warns about this. No need for that, so use __VA_ARGS__ everywhere.