### PR TITLE
ci: setup multi-arch build and runtime testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,48 @@
+name: Build and Test Multiple Architectures
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        architecture: [x86_64, arm64]
+        include:
+          - architecture: x86_64
+            cross_compiler:
+          - architecture: arm64
+            cross_compiler: aarch64-linux-gnu-
+
+    steps:
+    # Checkout code
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # Set up dependencies
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          gcc \
+          g++ \
+          qemu-user-static \
+          gcc-aarch64-linux-gnu
+
+    # Run cross-compilation using make
+    - name: Cross-compile for ${{ matrix.architecture }}
+      run: |
+        make ARCH=${{ matrix.architecture }} CROSS_COMPILE=${{ matrix.cross_compiler }} build
+
+    # Optional: Test the binary with QEMU
+    #- name: Test binary on ${{ matrix.architecture }} using QEMU
+    #  run: |
+    #    sudo apt-get install -y qemu qemu-user
+    #    qemu-${{ matrix.architecture }}-static ./output_binary
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,6 +5,13 @@ BPFTRACE ?= bpftrace
 OUTPUT ?= .output
 SHARED ?= 0
 
+ifneq ($(CROSS_COMPILE),)
+CC = $(CROSS_COMPILE)gcc
+CXX = $(CROSS_COMPILE)g++
+LD = $(CROSS_COMPILE)ld
+AR = $(CROSS_COMPILE)ar
+endif
+
 export AWK READELF BPFTRACE
 
 ifeq ($(V),1)


### PR DESCRIPTION
Add a simple setup that cross-compiles tests and runs them under qemu for a few supported architectures.