### PR TITLE
lib: stop enforcing .stapsdt.base to be preserved

### DIFF
--- a/usdt.h
+++ b/usdt.h
@@ -372,7 +372,7 @@ struct usdt_sema { volatile unsigned short active; };
 	__usdt_asm1(994:	.balign 4)							\
 	__usdt_asm1(		.popsection)							\
 	__usdt_asm1(.ifndef _.stapsdt.base)							\
-	__usdt_asm5(		.pushsection .stapsdt.base,"aGR","progbits",.stapsdt.base,comdat)\
+	__usdt_asm5(		.pushsection .stapsdt.base,"aG","progbits",.stapsdt.base,comdat)\
 	__usdt_asm1(		.weak _.stapsdt.base)						\
 	__usdt_asm1(		.hidden _.stapsdt.base)						\
 	__usdt_asm1(_.stapsdt.base:)								\


### PR DESCRIPTION
We currently mark .stapsdt.base section as "R" which means:

  retained section (apply SHF_GNU_RETAIN to prevent linker garbage collection, GNU ELF extension)

But in some more complicated production build environments, ELF note's base addressed is zeroed out (for whatever reason), but .stapsdt.base is preserved due to R (it's not without it).

This leads to an interesting unintended interaction inside libbpf logic where base address is there, globally, due to the presence of .stapsdt.base ELF section, and libbpf just blindly assumes that USDT note relies on .stapsdt.base, but the recorded base addr inside USDT metadata (ELF note) is zero. Which leads to incorrectly adjusted USDT semaphore address, leading to USDT attachment errors.